### PR TITLE
feat: Visual selection context support for editing remarks and fixes empty lines being

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Neovim plugin for [git-remarks](https://github.com/Enigama/git-remarks) — pers
 - **Bring your own picker** — Use telescope, fzf-lua, mini.pick, snacks.nvim, or any picker you prefer
 - **Quick add** — Add remarks via input prompt
 - **Full add** — Add remarks with YAML template in a buffer
+- **Visual selection context** — Automatically add file context from visual selection when editing remarks
 - **Configurable** — Float, split, vsplit, or tab for edit buffers
 - **Zero dependencies** — Falls back to `vim.ui.select()` when no picker is configured
 
@@ -71,6 +72,16 @@ By default, remarks.nvim uses `vim.ui.select()` which works out of the box and c
 To use a custom picker, provide a function that receives:
 - `remarks` — List of remark objects with fields: `id`, `type`, `age`, `sha`, `is_head`, `body`
 - `opts` — Options table (e.g., `{ commit = "HEAD" }` when filtering by commit)
+
+### Recommended Keybindings
+
+| Key | Action |
+|-----|--------|
+| `<CR>` | Edit selected remark |
+| `<C-e>` | Edit remark with visual selection context |
+| `d` / `x` / `<C-d>` | Resolve (delete) selected remark |
+| `a` / `<C-a>` | Add new remark |
+| `<C-t>` | Edit selected remark in new tab |
 
 ### Telescope
 
@@ -187,6 +198,18 @@ To use a custom picker, provide a function that receives:
           map("i", "<C-t>", edit_in_tab)
           map("n", "<C-t>", edit_in_tab)
 
+          -- <C-e> - Edit with visual selection context
+          local edit_with_context = function()
+            local selection = action_state.get_selected_entry()
+            actions.close(prompt_bufnr)
+            if selection then
+              require("remarks.buffer").edit_remark(selection.value, { include_visual_context = true })
+            end
+          end
+
+          map("i", "<C-e>", edit_with_context)
+          map("n", "<C-e>", edit_with_context)
+
           return true
         end,
       }):find()
@@ -284,6 +307,12 @@ To use a custom picker, provide a function that receives:
               end
             end
           end,
+          ["ctrl-e"] = function(selected)
+            if selected[1] then
+              local remark = remark_map[selected[1]]
+              require("remarks.buffer").edit_remark(remark, { include_visual_context = true })
+            end
+          end,
         },
       })
     end
@@ -330,6 +359,20 @@ To use a custom picker, provide a function that receives:
               end)
             end
           end,
+        },
+        mappings = {
+          edit_context = {
+            char = "<C-e>",
+            func = function()
+              local item = MiniPick.get_picker_matches().current
+              if item then
+                MiniPick.stop()
+                vim.schedule(function()
+                  require("remarks.buffer").edit_remark(item.remark, { include_visual_context = true })
+                end)
+              end
+            end,
+          },
         },
       })
     end
@@ -393,6 +436,22 @@ To use a custom picker, provide a function that receives:
             require("remarks.buffer").edit_remark(item.remark)
           end
         end,
+        actions = {
+          edit_context = function(picker)
+            local item = picker:current()
+            picker:close()
+            if item then
+              require("remarks.buffer").edit_remark(item.remark, { include_visual_context = true })
+            end
+          end,
+        },
+        win = {
+          input = {
+            keys = {
+              ["<C-e>"] = { "edit_context", mode = { "i", "n" } },
+            },
+          },
+        },
       })
     end
 
@@ -430,6 +489,13 @@ To use a custom picker, provide a function that receives:
 
 " Show remarks on current commit
 :RemarksShow
+
+" Edit remark with visual selection context
+" 1. Make a visual selection in your file (e.g., lines 25-35)
+" 2. Open :Remarks picker
+" 3. Press <C-e> on a remark
+" 4. File context (file: path/to/file.ts:25-35) is automatically added
+" 5. Start typing your comment immediately (already in insert mode)
 ```
 
 ## License

--- a/lua/remarks/buffer.lua
+++ b/lua/remarks/buffer.lua
@@ -2,11 +2,146 @@ local M = {}
 
 local git = require("remarks.git")
 
+--- Get file path relative to git root
+---@param bufnr number Buffer number
+---@return string|nil
+local function get_file_path(bufnr)
+  local file = vim.api.nvim_buf_get_name(bufnr)
+  if file == "" then
+    return nil
+  end
+
+  -- Get git root
+  local git_root_result = vim.system({ "git", "rev-parse", "--show-toplevel" }, { text = true }):wait()
+  if git_root_result.code ~= 0 then
+    -- Not in a git repo, return relative to cwd
+    return vim.fn.fnamemodify(file, ":.")
+  end
+
+  local git_root = vim.trim(git_root_result.stdout)
+  local abs_file = vim.fn.fnamemodify(file, ":p")
+
+  -- Make path relative to git root
+  if abs_file:sub(1, #git_root) == git_root then
+    local rel_path = abs_file:sub(#git_root + 2) -- +2 to skip the trailing /
+    return rel_path
+  end
+
+  return vim.fn.fnamemodify(file, ":.")
+end
+
+--- Get line range from visual selection marks
+---@param bufnr number Buffer number
+---@return number|nil start_line, number|nil end_line
+local function get_visual_selection_range(bufnr)
+  -- Try multiple methods to get visual selection marks
+  
+  -- Method 1: Use vim.fn.line() - simplest approach
+  local ok1, start_line1 = pcall(vim.fn.line, "'<")
+  local ok2, end_line1 = pcall(vim.fn.line, "'>")
+  
+  if ok1 and ok2 and start_line1 and end_line1 and start_line1 > 0 and end_line1 > 0 then
+    local start = start_line1
+    local end_line = end_line1
+    if start > end_line then
+      start, end_line = end_line, start
+    end
+    return start, end_line
+  end
+  
+  -- Method 2: Use getpos as fallback
+  local ok3, start_pos = pcall(vim.fn.getpos, "'<")
+  local ok4, end_pos = pcall(vim.fn.getpos, "'>")
+  
+  if ok3 and ok4 and start_pos and end_pos and #start_pos >= 2 and #end_pos >= 2 then
+    local start = start_pos[2]
+    local end_line = end_pos[2]
+    if start > 0 and end_line > 0 then
+      if start > end_line then
+        start, end_line = end_line, start
+      end
+      return start, end_line
+    end
+  end
+
+  return nil, nil
+end
+
+--- Format file context string
+---@param file_path string|nil File path
+---@param start_line number|nil Start line number
+---@param end_line number|nil End line number
+---@return string|nil
+local function format_file_context(file_path, start_line, end_line)
+  if not file_path then
+    return nil
+  end
+
+  if not start_line then
+    return nil
+  end
+
+  if end_line and end_line ~= start_line then
+    return string.format("file: %s:%d-%d", file_path, start_line, end_line)
+  else
+    return string.format("file: %s:%d", file_path, start_line)
+  end
+end
+
+--- Get file context from visual selection
+---@param bufnr number|nil Buffer number (optional, will use buffer from marks if not provided)
+---@return string|nil
+local function get_file_context_from_selection(bufnr)
+  -- Get the buffer number from visual selection marks
+  local mark_bufnr = bufnr
+  local start_line, end_line = nil, nil
+  
+  -- Try to get buffer number and line numbers from marks
+  local ok1, start_pos = pcall(vim.fn.getpos, "'<")
+  local ok2, end_pos = pcall(vim.fn.getpos, "'>")
+  
+  if ok1 and ok2 and start_pos and end_pos and #start_pos >= 4 and #end_pos >= 4 then
+    -- getpos returns [bufnum, lnum, col, off]
+    mark_bufnr = start_pos[1]  -- Buffer number where mark is set
+    start_line = start_pos[2]   -- Line number
+    end_line = end_pos[2]      -- Line number
+    
+    if start_line > 0 and end_line > 0 then
+      if start_line > end_line then
+        start_line, end_line = end_line, start_line
+      end
+    else
+      return nil
+    end
+  else
+    -- Fallback to using provided bufnr and line() function
+    if not bufnr then
+      return nil
+    end
+    start_line, end_line = get_visual_selection_range(bufnr)
+    if not start_line then
+      return nil
+    end
+    mark_bufnr = bufnr
+  end
+  
+  -- Get file path from the buffer that has the marks
+  local file_path = get_file_path(mark_bufnr)
+  if not file_path then
+    return nil
+  end
+
+  return format_file_context(file_path, start_line, end_line)
+end
+
 --- Quick add a remark via vim.ui.input
 ---@param remark_type string|nil Remark type (default from config)
 function M.quick_add(remark_type)
   local config = require("remarks").config
   remark_type = remark_type or config.default_type
+
+  local bufnr = vim.api.nvim_get_current_buf()
+  local file_context = get_file_context_from_selection(bufnr)
 
   vim.ui.input({
     prompt = "Remark (" .. remark_type .. "): ",
@@ -15,7 +150,12 @@ function M.quick_add(remark_type)
       return
     end
 
-    local result = git.add(input, { type = remark_type })
+    local body = input
+    if file_context then
+      body = file_context .. "\n" .. body
+    end
+
+    local result = git.add(body, { type = remark_type })
     if result.success then
       vim.notify(result.output, vim.log.levels.INFO)
     else
@@ -30,6 +170,9 @@ function M.full_add()
   local branch = git.get_branch() or "unknown"
   local head = git.get_head() or "HEAD"
 
+  local bufnr = vim.api.nvim_get_current_buf()
+  local file_context = get_file_context_from_selection(bufnr)
+
   local template = {
     "# New remark on " .. head .. " (" .. branch .. ")",
     "# Save and close to add, :q! to cancel",
@@ -38,8 +181,15 @@ function M.full_add()
     "",
     "---",
     "",
-    "",
   }
+
+  -- Add file context if visual selection exists
+  if file_context then
+    table.insert(template, file_context)
+    table.insert(template, "")
+  else
+    table.insert(template, "")
+  end
 
   M.open_buffer({
     title = "New Remark",
@@ -65,37 +215,65 @@ end
 
 --- Edit an existing remark
 ---@param remark table Remark object from git.list()
----@param opts { style: string|nil }|nil Options (style overrides config)
+---@param opts { style: string|nil, include_visual_context: boolean|nil }|nil Options (style overrides config, include_visual_context captures visual selection)
 function M.edit_remark(remark, opts)
   opts = opts or {}
   local config = require("remarks").config
   local branch = git.get_branch() or "unknown"
   local style_override = opts.style
+  local include_visual_context = opts.include_visual_context or false
 
-  local lines = {
-    "# Editing remark [" .. remark.id .. "] on " .. remark.sha .. " (" .. branch .. ")",
-    "# Save and close to update, :q! to cancel",
-    "",
-    "type: " .. remark.type,
-    "",
-    "---",
-    "",
-  }
+  -- Capture visual selection context only when explicitly requested
+  local file_context = nil
+  if include_visual_context then
+    file_context = get_file_context_from_selection()
+    if not file_context then
+      vim.notify("No visual selection found", vim.log.levels.WARN)
+    end
+  end
 
-  -- Add body lines
-  for line in remark.body:gmatch("[^\r\n]+") do
+  local header_comment = "# Editing remark [" .. remark.id .. "] on " .. remark.sha .. " (" .. branch .. ")"
+  if file_context then
+    header_comment = header_comment .. "\n# Visual selection detected - file context added below"
+  end
+  header_comment = header_comment .. "\n# Save and close to update, :q! to cancel"
+
+  local lines = {}
+  for line in header_comment:gmatch("[^\r\n]+") do
+    table.insert(lines, line)
+  end
+  table.insert(lines, "")
+  table.insert(lines, "type: " .. remark.type)
+  table.insert(lines, "")
+  table.insert(lines, "---")
+  table.insert(lines, "")
+
+  -- Add body lines (existing content - preserved)
+  local body_lines = vim.split(remark.body, "\n", { plain = true })
+  for _, line in ipairs(body_lines) do
     table.insert(lines, line)
   end
 
-  -- Ensure at least one empty line for editing
-  if remark.body == "" then
+  -- Add file context at the bottom if visual selection exists
+  if file_context then
+    -- Add spacing and explanation before the new file context
+    if remark.body ~= "" and not remark.body:match("\n%s*$") then
+      table.insert(lines, "")
+    end
+    table.insert(lines, file_context)
     table.insert(lines, "")
+  else
+    -- Ensure at least one empty line for editing if no file context
+    if remark.body == "" then
+      table.insert(lines, "")
+    end
   end
 
   M.open_buffer({
     title = "Remark [" .. remark.id .. "]",
     lines = lines,
     style = style_override,
+    start_in_insert = include_visual_context,
     on_save = function(new_lines)
       local new_type, new_body = M.parse_remark_buffer(new_lines)
       if not new_body or new_body == "" then
@@ -157,15 +335,26 @@ function M.parse_remark_buffer(lines)
     ::continue::
   end
 
-  local body = vim.trim(table.concat(body_lines, "\n"))
+  -- Remove leading empty lines
+  while #body_lines > 0 and body_lines[1] == "" do
+    table.remove(body_lines, 1)
+  end
+  -- Remove trailing empty lines
+  while #body_lines > 0 and body_lines[#body_lines] == "" do
+    table.remove(body_lines, #body_lines)
+  end
+  
+  -- Join lines, preserving internal empty lines
+  local body = table.concat(body_lines, "\n")
   return remark_type, body
 end
 
 --- Open a buffer for editing
----@param opts { title: string, lines: string[], on_save: function, style: string|nil }
+---@param opts { title: string, lines: string[], on_save: function, style: string|nil, start_in_insert: boolean|nil }
 function M.open_buffer(opts)
   local config = require("remarks").config
   local style = opts.style or config.edit.style
+  local start_in_insert = opts.start_in_insert or false
 
   local buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, opts.lines)
@@ -231,15 +420,30 @@ function M.open_buffer(opts)
     vim.api.nvim_win_close(win, true)
   end, { buffer = buf, desc = "Close remark buffer" })
 
-  -- Position cursor at the body
-  local body_start = 1
-  for i, line in ipairs(opts.lines) do
-    if line:match("^%-%-%-") then
-      body_start = i + 2
-      break
+  -- Position cursor
+  local cursor_line
+  if start_in_insert then
+    -- When starting in insert mode, position at the end (where new comments go)
+    cursor_line = #opts.lines
+  else
+    -- Normal mode: position at the body start
+    local body_start = 1
+    for i, line in ipairs(opts.lines) do
+      if line:match("^%-%-%-") then
+        body_start = i + 2
+        break
+      end
     end
+    cursor_line = math.min(body_start, #opts.lines)
   end
-  vim.api.nvim_win_set_cursor(win, { math.min(body_start, #opts.lines), 0 })
+  vim.api.nvim_win_set_cursor(win, { cursor_line, 0 })
+
+  -- Enter insert mode if requested (use schedule to ensure window is ready)
+  if start_in_insert then
+    vim.schedule(function()
+      vim.cmd("startinsert")
+    end)
+  end
 end
 
 return M

--- a/lua/remarks/init.lua
+++ b/lua/remarks/init.lua
@@ -20,11 +20,5 @@ function M.setup(opts)
   require("remarks.commands").setup()
 end
 
---- Check if git-remarks CLI is available
----@return boolean
-function M.is_available()
-  return vim.fn.executable("git-remarks") == 1
-end
-
 return M
 


### PR DESCRIPTION
## Features

### Visual Selection Context Support

- **New `<C-e>` keybinding**: Edit remarks with automatic file context from visual selection
  - Make a visual selection in your file (e.g., lines 25-35)
  - Open `:Remarks` picker
  - Press `<C-e>` on any remark
  - File context (`file: path/to/file.ts:25-35`) is automatically appended
  - Buffer opens in insert mode for immediate typing

- **Explicit workflow**: Unlike `<CR>` which opens in normal mode, `<C-e>` provides an explicit way to add context-aware comments

### Bug Fixes

- **Empty lines preservation**: Fixed empty lines being lost when:
  - Saving remarks (parsing buffer content)
  - Loading remarks from git-remarks (parsing list output)
  - Displaying remarks in Telescope preview

## Technical Changes

### Added
- `include_visual_context` option to `edit_remark()` function
- `start_in_insert` option to `open_buffer()` function
- Visual selection context detection that works even when called from Telescope buffer
- `<C-e>` keybinding in Telescope picker

### Fixed
- `parse_remark_buffer()` now preserves internal empty lines
- `parse_list_output()` now uses `vim.split()` instead of `gmatch()` to preserve empty lines
- Telescope preview now preserves empty lines

### Removed
- Unused `M.show()` function
- Unused `M.edit()` function  
- Unused `M.get_remark_yaml()` function
- Unused `M.is_available()` function

## Documentation

- Updated README with visual selection context feature
- Added `<C-e>` and `<C-t>` keybindings to Telescope keymaps table
- Added example workflow for using visual selection context

## Testing

- [x] Visual selection context is captured correctly from original buffer
- [x] Empty lines are preserved when saving and loading remarks
- [x] Edit buffer opens in insert mode with `<C-e>`
- [x] Normal edit with `<CR>` still works in normal mode

### Screenshots
<img width="1556" height="902" alt="image" src="https://github.com/user-attachments/assets/24af0e38-a376-49c3-8070-75b0961027a8" />
<img width="755" height="453" alt="image" src="https://github.com/user-attachments/assets/c20089b2-af10-4f4f-9b8e-4566cc659643" />
