### PR TITLE
docs: show body preview in telescope picker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,17 @@ To use a custom picker, provide a function that receives:
         finder = finders.new_table({
           results = remarks,
           entry_maker = function(remark)
+            -- Extract first line of body as preview
+            local preview = remark.body:match("^[^\r\n]+") or ""
+            if #preview > 50 then
+              preview = preview:sub(1, 47) .. "..."
+            end
+
             local display = string.format(
-              "[%s] %s · %s · %s%s",
+              "[%s] %s: %s%s",
               remark.id,
               remark.type,
-              remark.age,
-              remark.sha,
+              preview,
               remark.is_head and " (HEAD)" or ""
             )
             return {


### PR DESCRIPTION
Display first line of remark body in telescope entries for better scannability. Truncates preview to 50 chars.

**Before:** `[id] type · age · sha (HEAD)`
**After:** `[id] type: preview text... (HEAD)`